### PR TITLE
Synchronize streams on events to reduce polling

### DIFF
--- a/parsec/data.c
+++ b/parsec/data.c
@@ -68,7 +68,7 @@ static void parsec_data_construct(parsec_data_t* obj )
     for( uint32_t i = 0; i < parsec_nb_devices;
          obj->device_copies[i] = NULL, i++ );
     obj->dc               = NULL;
-    obj->lock             = unlocked; /* Can't directly assign to PARSEC_ATOMIC_UNLOCKED because of C syntax */
+    PARSEC_DATA_SET_LOCK(obj, unlocked); /* Can't directly assign to PARSEC_ATOMIC_UNLOCKED because of C syntax */
     PARSEC_DEBUG_VERBOSE(20, parsec_debug_output, "Allocate data %p", obj);
 }
 
@@ -288,10 +288,10 @@ int parsec_data_transfer_ownership_to_copy(parsec_data_t* data,
                                            uint8_t access_mode)
 {
     int transfer_required;
-    parsec_atomic_lock(&data->lock);
+    PARSEC_DATA_LOCK(data);
     transfer_required = parsec_data_start_transfer_ownership_to_copy(data, device, access_mode);
     parsec_data_end_transfer_ownership_to_copy(data, device, access_mode);
-    parsec_atomic_unlock(&data->lock);
+    PARSEC_DATA_UNLOCK(data);
     return transfer_required;
 }
 

--- a/parsec/mca/device/cuda/device_cuda_module.c
+++ b/parsec/mca/device/cuda/device_cuda_module.c
@@ -361,7 +361,7 @@ static int parsec_cuda_stream_wait_event(struct parsec_device_gpu_module_s *sour
     cudaError_t cudaStatus;
     (void)source_gpu;
     (void)target_gpu;
-    cudaStatus = cudaStreamWaitEvent(cuda_target_stream->cudaStream, cuda_source_stream->events[source_event_idx], 0);
+    cudaStatus = cudaStreamWaitEvent(cuda_target_stream->cuda_stream, cuda_source_stream->events[source_event_idx], 0);
     PARSEC_CUDA_CHECK_ERROR( "cudaStreamWaitEvent", cudaStatus, {return PARSEC_ERROR;} );
     return PARSEC_SUCCESS;
 }

--- a/parsec/mca/device/device.c
+++ b/parsec/mca/device/device.c
@@ -408,10 +408,10 @@ void parsec_compute_best_unit( uint64_t length, float* updated_value, char** bes
 
 void parsec_devices_save_statistics(uint64_t **pstats) {
     if(NULL == *pstats) {
-        *pstats = (uint64_t*)calloc(sizeof(uint64_t), parsec_nb_devices * 6 /* see below for the number of arrays */);
+        *pstats = (uint64_t*)calloc(sizeof(uint64_t), parsec_nb_devices * 7 /* see below for the number of arrays */);
     }
     else {
-        memset(*pstats, 0, parsec_nb_devices * sizeof(uint64_t) * 6);
+        memset(*pstats, 0, parsec_nb_devices * sizeof(uint64_t) * 7);
     }
     uint64_t *stats = *pstats;
     uint64_t *executed_tasks = stats;
@@ -420,6 +420,7 @@ void parsec_devices_save_statistics(uint64_t **pstats) {
     uint64_t *req_in         = stats + 3*parsec_nb_devices;
     uint64_t *req_out        = stats + 4*parsec_nb_devices;
     uint64_t *transfer_d2d   = stats + 5*parsec_nb_devices;
+    uint64_t *nb_records     = stats + 6*parsec_nb_devices;
 
     for(uint32_t i = 0; i < parsec_nb_devices; i++) {
         parsec_device_module_t *device = parsec_devices[i];
@@ -430,6 +431,7 @@ void parsec_devices_save_statistics(uint64_t **pstats) {
         transfer_out[i]   = device->data_out_to_host;
         req_in[i]         = device->required_data_in;
         req_out[i]        = device->required_data_out;
+        nb_records[i]     = device->nb_records;
         for(unsigned int j = 1; j < device->data_in_array_size; j++) /* d2d */
             transfer_d2d[i] += device->data_in_from_device[j];
         /* don't compute global stats yet, do it during print */
@@ -445,7 +447,7 @@ void parsec_devices_free_statistics(uint64_t **pstats) {
 void parsec_devices_print_statistics(parsec_context_t *parsec_context, uint64_t *start_stats) {
     uint64_t *end_stats = NULL;
     uint64_t total_tasks = 0, total_data_in = 0, total_data_out = 0;
-    uint64_t total_required_in = 0, total_required_out = 0, total_d2d = 0;
+    uint64_t total_required_in = 0, total_required_out = 0, total_d2d = 0, total_records = 0;
     float gtotal = 0.0;
     float best_data_in, best_data_out, best_d2d;
     float best_required_in, best_required_out;
@@ -457,7 +459,7 @@ void parsec_devices_print_statistics(parsec_context_t *parsec_context, uint64_t 
     /* initialize the arrays */
     parsec_devices_save_statistics(&end_stats);
     if(NULL != start_stats) {
-        for(i = 0; i < parsec_nb_devices * 6; i++) {
+        for(i = 0; i < parsec_nb_devices * 7; i++) {
             assert(end_stats[i] >= start_stats[i]);
             end_stats[i] -= start_stats[i];
         }
@@ -468,6 +470,7 @@ void parsec_devices_print_statistics(parsec_context_t *parsec_context, uint64_t 
     uint64_t *required_in       = end_stats + 3*parsec_nb_devices;
     uint64_t *required_out      = end_stats + 4*parsec_nb_devices;
     uint64_t *transferred_d2d   = end_stats + 5*parsec_nb_devices;
+    uint64_t *nb_records        = end_stats + 6*parsec_nb_devices;
 
     /* Compute total statistics */
     for(i = 0; i < parsec_nb_devices; i++) {
@@ -479,17 +482,18 @@ void parsec_devices_print_statistics(parsec_context_t *parsec_context, uint64_t 
         total_required_in  += required_in[i];
         total_required_out += required_out[i];
         total_d2d          += transferred_d2d[i];
+        total_records      += nb_records[i];
     }
 
     /* Print statistics */
     gtotal = (float)total_tasks;
     double percent_in, percent_out, percent_d2d;
 
-    printf("+----------------------------------------------------------------------------------------------------------------------------+\n");
-    printf("|         |                    |                       Data In                              |         Data Out               |\n");
-    printf("|Rank %3d |  # KERNEL |    %%   |  Required  |   Transfered H2D(%%)   |   Transfered D2D(%%)   |  Required  |   Transfered(%%)   |\n",
+    printf("+-----------------------------------------------------------------------------------------------------------------------------------------+\n");
+    printf("|         |                    |                       Data In                              |         Data Out               |            |\n");
+    printf("|Rank %3d |  # KERNEL |    %%   |  Required  |   Transfered H2D(%%)   |   Transfered D2D(%%)   |  Required  |   Transfered(%%)   |  # records |\n",
            (NULL == parsec_context ? parsec_debug_rank : parsec_context->my_rank));
-    printf("|---------|-----------|--------|------------|-----------------------|-----------------------|------------|-------------------|\n");
+    printf("|---------|-----------|--------|------------|-----------------------|-----------------------|------------|-------------------|------------|\n");
     for( i = 0; i < parsec_nb_devices; i++ ) {
         if( NULL == (device = parsec_devices[i]) ) continue;
 
@@ -503,15 +507,16 @@ void parsec_devices_print_statistics(parsec_context_t *parsec_context, uint64_t 
         percent_d2d = (0 == required_in[i])? nan(""): (((double)transferred_d2d[i])  / (double)required_in[i] ) * 100.0;
         percent_out = (0 == required_out[i])? nan(""): (((double)transferred_out[i])  / (double)required_out[i] ) * 100.0;
 
-        printf("|  Dev %2d |%10"PRIu64" | %6.2f | %8.2f%2s |   %8.2f%2s(%5.2f)   |   %8.2f%2s(%5.2f)   | %8.2f%2s | %8.2f%2s(%5.2f) | %s\n",
+        printf("|  Dev %2d |%10"PRIu64" | %6.2f | %8.2f%2s |   %8.2f%2s(%5.2f)   |   %8.2f%2s(%5.2f)   | %8.2f%2s | %8.2f%2s(%5.2f) | %10"PRIu64" | %s\n",
                device->device_index, executed_tasks[i], (executed_tasks[i]/gtotal)*100.00,
                best_required_in,  required_in_unit,  best_data_in,  data_in_unit, percent_in,
                best_d2d, d2d_unit, percent_d2d,
                best_required_out, required_out_unit, best_data_out, data_out_unit, percent_out,
+               nb_records[i],
                device->name );
     }
 
-    printf("|---------|-----------|--------|------------|-----------------------|-----------------------|------------|-------------------|\n");
+    printf("|---------|-----------|--------|------------|-----------------------|-----------------------|------------|-------------------|------------|\n");
 
     parsec_compute_best_unit( total_required_in,  &best_required_in,  &required_in_unit  );
     parsec_compute_best_unit( total_required_out, &best_required_out, &required_out_unit );
@@ -523,12 +528,12 @@ void parsec_devices_print_statistics(parsec_context_t *parsec_context, uint64_t 
     percent_d2d = (0 == total_required_in)? nan(""): (((double)total_d2d)  / (double)total_required_in) * 100.0;
     percent_out = (0 == total_required_out)? nan(""): (((double)total_data_out)  / (double)total_required_out) * 100.0;
 
-    printf("|All Devs |%10"PRIu64" | %6.2f | %8.2f%2s |   %8.2f%2s(%5.2f)   |   %8.2f%2s(%5.2f)   | %8.2f%2s | %8.2f%2s(%5.2f) |\n",
+    printf("|All Devs |%10"PRIu64" | %6.2f | %8.2f%2s |   %8.2f%2s(%5.2f)   |   %8.2f%2s(%5.2f)   | %8.2f%2s | %8.2f%2s(%5.2f) | %10"PRIu64" |\n",
            total_tasks, (total_tasks/gtotal)*100.00,
            best_required_in,  required_in_unit,  best_data_in,  data_in_unit, percent_in,
            best_d2d, d2d_unit, percent_d2d,
-           best_required_out, required_out_unit, best_data_out, data_out_unit, percent_out);
-    printf("+----------------------------------------------------------------------------------------------------------------------------+\n");
+           best_required_out, required_out_unit, best_data_out, data_out_unit, percent_out, total_records);
+    printf("+-----------------------------------------------------------------------------------------------------------------------------------------+\n");
 
     parsec_devices_free_statistics(&end_stats);
 }
@@ -545,6 +550,7 @@ void parsec_mca_device_reset_statistics(parsec_context_t *parsec_context) {
         device->data_out_to_host     = 0;
         device->required_data_in     = 0;
         device->required_data_out    = 0;
+        device->nb_records           = 0;
     }
 }
 

--- a/parsec/mca/device/device.h
+++ b/parsec/mca/device/device.h
@@ -164,6 +164,7 @@ struct parsec_device_module_s {
     uint64_t  required_data_in;
     uint64_t  required_data_out;
     uint64_t  executed_tasks;
+    uint64_t  nb_records;
     uint64_t  nb_data_faults;
     /* We provide the compute capacity of the device in GFlop/s so that conversion to #nanosec in load estimates is straightforward */
     /* These compute capacities can be useful for users when providing their own

--- a/parsec/mca/device/device_gpu.c
+++ b/parsec/mca/device/device_gpu.c
@@ -1439,7 +1439,7 @@ parsec_device_data_stage_in( parsec_device_gpu_module_t* gpu_device,
             PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,
                                  "GPU[%d:%s]:\tThere is a potential alternative source for data_in %p [ref_count %d] in original %p to go in copy %p [ref_count %d], but it is not ready, falling back on CPU source",
                                  gpu_device->super.device_index, gpu_device->super.name, task_data->data_in, task_data->data_in->super.super.obj_reference_count, original, gpu_elem, gpu_elem->super.super.obj_reference_count);
-            //return PARSEC_HOOK_RETURN_NEXT;
+            return PARSEC_HOOK_RETURN_AGAIN;
         }
 
         /* We fall back on the CPU copy */
@@ -1891,6 +1891,8 @@ parsec_device_progress_stream( parsec_device_gpu_module_t* gpu_device,
     rc = progress_fct( gpu_device, task, stream );
     if(0 == rc) {
         /* If progress_fct added nothing on that stream, we skip scheduling a record on the GPU stream */
+        if( task->complete_stage )
+            rc = task->complete_stage(gpu_device, &task, stream);
         *out_task = task;
         return rc;
     }
@@ -2021,7 +2023,7 @@ parsec_device_kernel_push( parsec_device_gpu_module_t      *gpu_device,
             gpu_task->last_status = ret;
             return ret;
         }
-        how_many++;
+        how_many += ret;
     }
 
     PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,

--- a/parsec/mca/device/device_gpu.c
+++ b/parsec/mca/device/device_gpu.c
@@ -1439,7 +1439,10 @@ parsec_device_data_stage_in( parsec_device_gpu_module_t* gpu_device,
             PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,
                                  "GPU[%d:%s]:\tThere is a potential alternative source for data_in %p [ref_count %d] in original %p to go in copy %p [ref_count %d], but it is not ready, falling back on CPU source",
                                  gpu_device->super.device_index, gpu_device->super.name, task_data->data_in, task_data->data_in->super.super.obj_reference_count, original, gpu_elem, gpu_elem->super.super.obj_reference_count);
+            /* TODO: test this 
+            PARSEC_DATA_UNLOCK(original);
             return PARSEC_HOOK_RETURN_AGAIN;
+            */
         }
 
         /* We fall back on the CPU copy */
@@ -1891,9 +1894,9 @@ parsec_device_progress_stream( parsec_device_gpu_module_t* gpu_device,
     rc = progress_fct( gpu_device, task, stream );
     if(0 == rc) {
         /* If progress_fct added nothing on that stream, we skip scheduling a record on the GPU stream */
-        if( task->complete_stage )
-            rc = task->complete_stage(gpu_device, &task, stream);
         *out_task = task;
+        if( task->complete_stage )
+            rc = task->complete_stage(gpu_device, out_task, stream);
         return rc;
     }
     if( 0 > rc ) {

--- a/parsec/mca/device/device_gpu.c
+++ b/parsec/mca/device/device_gpu.c
@@ -38,6 +38,13 @@ static int parsec_gpu_profiling_initiated = 0;
 int parsec_gpu_output_stream = -1;
 int parsec_gpu_verbosity;
 
+/* The return value of these functions is either a parsec_hook_return_t for <= 0 values,
+ * or a positive number which represents that something has been scheduled on the gpu_stream
+ */
+typedef int(*parsec_gpu_step_function_t)(parsec_device_gpu_module_t  *gpu_device,
+                                         parsec_gpu_task_t           *gpu_task,
+                                         parsec_gpu_exec_stream_t    *gpu_stream);
+
 static inline int
 parsec_device_check_space_needed(parsec_device_gpu_module_t *gpu_device,
                                  parsec_gpu_task_t *gpu_task)
@@ -1810,7 +1817,7 @@ parsec_device_callback_complete_push(parsec_device_gpu_module_t   *gpu_device,
 static inline int
 parsec_device_progress_stream( parsec_device_gpu_module_t* gpu_device,
                                parsec_gpu_exec_stream_t* stream,
-                               parsec_advance_task_function_t progress_fct,
+                               parsec_gpu_step_function_t progress_fct,
                                parsec_gpu_task_t* task,
                                parsec_gpu_task_t** out_task )
 {
@@ -1869,6 +1876,7 @@ parsec_device_progress_stream( parsec_device_gpu_module_t* gpu_device,
     }
 
  grab_a_task:
+    assert(NULL == task);
     if( NULL == stream->tasks[stream->start] ) {  /* there is room on the stream */
         task = (parsec_gpu_task_t*)parsec_list_pop_front(stream->fifo_pending);  /* get the best task */
     }
@@ -1881,6 +1889,11 @@ parsec_device_progress_stream( parsec_device_gpu_module_t* gpu_device,
 
   schedule_task:
     rc = progress_fct( gpu_device, task, stream );
+    if(0 == rc) {
+        /* If progress_fct added nothing on that stream, we skip scheduling a record on the GPU stream */
+        *out_task = task;
+        return rc;
+    }
     if( 0 > rc ) {
         if( PARSEC_HOOK_RETURN_AGAIN != rc ) {
            *out_task = task;
@@ -1899,7 +1912,6 @@ parsec_device_progress_stream( parsec_device_gpu_module_t* gpu_device,
                              "trigger the task will be handled accordingly",
                              gpu_device->super.device_index, gpu_device->super.name, (void*)task);
     }
-    task->last_status = rc;
     /**
      * Do not skip the gpu event generation. The problem is that some of the inputs
      * might be in the pipe of being transferred to the GPU. If we activate this task
@@ -1939,7 +1951,7 @@ parsec_device_kernel_push( parsec_device_gpu_module_t      *gpu_device,
 {
     parsec_task_t *this_task = gpu_task->ec;
     const parsec_flow_t *flow;
-    int i, ret = 0;
+    int i, ret = 0, how_many = 0;
 #if defined(PARSEC_DEBUG_NOISIER)
     char tmp[MAX_TASK_STRLEN];
 #endif
@@ -2009,6 +2021,7 @@ parsec_device_kernel_push( parsec_device_gpu_module_t      *gpu_device,
             gpu_task->last_status = ret;
             return ret;
         }
+        how_many++;
     }
 
     PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,
@@ -2019,7 +2032,7 @@ parsec_device_kernel_push( parsec_device_gpu_module_t      *gpu_device,
 #if defined(PARSEC_PROF_TRACE)
     gpu_task->prof_key_end = -1; /* We do not log that event as the completion of this task */
 #endif
-    return PARSEC_HOOK_RETURN_DONE;
+    return how_many;
 }
 
 /**
@@ -2036,6 +2049,7 @@ parsec_device_kernel_exec( parsec_device_gpu_module_t      *gpu_device,
 {
     parsec_advance_task_function_t progress_fct = gpu_task->submit;
     parsec_task_t* this_task = gpu_task->ec;
+    int rc;
 
 #if defined(PARSEC_DEBUG_NOISIER)
     char tmp[MAX_TASK_STRLEN];
@@ -2072,7 +2086,9 @@ parsec_device_kernel_exec( parsec_device_gpu_module_t      *gpu_device,
 #endif /* defined(PARSEC_DEBUG_PARANOID) */
 
     (void)this_task;
-    return progress_fct( gpu_device, gpu_task, gpu_stream );
+    rc = progress_fct( gpu_device, gpu_task, gpu_stream );
+    gpu_task->last_status = rc;
+    return 1;
 }
 
 /**
@@ -2113,8 +2129,9 @@ parsec_device_kernel_pop( parsec_device_gpu_module_t   *gpu_device,
                 return_code = PARSEC_HOOK_RETURN_DISABLE;
                 goto release_and_return_error;
             }
+            how_many++;
         }
-        return PARSEC_HOOK_RETURN_DONE;
+        return how_many;
     }
 
     PARSEC_DEBUG_VERBOSE(10, parsec_gpu_output_stream,

--- a/parsec/mca/device/device_gpu.h
+++ b/parsec/mca/device/device_gpu.h
@@ -156,6 +156,20 @@ typedef int (*parsec_device_memcpy_async_fn_t)(struct parsec_device_gpu_module_s
 typedef int (*parsec_device_event_record_fn_t)(struct parsec_device_gpu_module_s *gpu, struct parsec_gpu_exec_stream_s *gpu_stream, int32_t event_idx);
 
 /**
+ * @brief Synchronize @p target_gpu_stream of GPU @p target_gpu with the record with index @p idx on @p source_gpu_stream of GPU @p source_gpu.
+ *
+ * @details typically maps to cudaStreamWaitEvent or equivalent. The GPU device must have allocated
+ *    @p gpu_stream->super.max_events previously (@p 0 <= event_idx < gpu_stream->super.max_events).
+ *
+ * @return PARSEC_SUCCESS or a PARSEC error
+ */
+typedef int (*parsec_device_stream_wait_event_fn_t)(struct parsec_device_gpu_module_s *source_gpu,
+                                                    struct parsec_gpu_exec_stream_s *source_gpu_stream,
+                                                    int32_t source_event_idx,
+                                                    struct parsec_device_gpu_module_s *target_gpu,
+                                                    struct parsec_gpu_exec_stream_s *target_gpu_stream);
+
+/**
  * @brief Record an event on the GPU @p gpu_stream of GPU @p gpu, with index @p idx.
  * 
  * @details typically maps to cudaRecordEvent or equivalent. The GPU device must have allocated
@@ -209,14 +223,15 @@ struct parsec_device_gpu_module_s {
     parsec_device_module_t     super;
 
     /* This set of base functions is used by the GPU devices to implement their Device Management Functions */
-    parsec_device_set_device_fn_t       set_device;
-    parsec_device_memcpy_async_fn_t     memcpy_async;
-    parsec_device_event_query_fn_t      event_query;
-    parsec_device_event_record_fn_t     event_record;
-    parsec_device_memory_info_fn_t      memory_info;
-    parsec_device_memory_allocate_fn_t  memory_allocate;
-    parsec_device_memory_free_fn_t      memory_free;
-    parsec_device_find_incarnation_fn_t find_incarnation;
+    parsec_device_set_device_fn_t        set_device;
+    parsec_device_memcpy_async_fn_t      memcpy_async;
+    parsec_device_event_query_fn_t       event_query;
+    parsec_device_event_record_fn_t      event_record;
+    parsec_device_stream_wait_event_fn_t stream_wait_event;
+    parsec_device_memory_info_fn_t       memory_info;
+    parsec_device_memory_allocate_fn_t   memory_allocate;
+    parsec_device_memory_free_fn_t       memory_free;
+    parsec_device_find_incarnation_fn_t  find_incarnation;
 
     uint8_t                    max_exec_streams;
     uint8_t                    num_exec_streams;


### PR DESCRIPTION
Currently synchronizes the exec stream on the input stream (if needed). We still poll on the output, since we may not yet know what outputs are needed.